### PR TITLE
Doc comment: Fix name of MatchingUserSessions func

### DIFF
--- a/ezproxy.go
+++ b/ezproxy.go
@@ -164,9 +164,9 @@ type SessionsReader interface {
 	// specific username or aggregating to check thresholds.
 	AllUserSessions() (UserSessions, error)
 
-	// UserSessions uses the previously provided username to return a list of
-	// all matching session IDs along with their associated IP Address in the
-	// form of a slice of UserSession values.
+	// MatchingUserSessions uses the previously provided username to return a
+	// list of all matching session IDs along with their associated IP Address
+	// in the form of a slice of UserSession values.
 	MatchingUserSessions() (UserSessions, error)
 
 	// SetSearchRetries is a helper method for setting the number of additional


### PR DESCRIPTION
This was missed when I renamed the method from `UserSessions` to `MatchingUserSessions` in an attempt to better clarify the purpose of the method.

The doc comments for each implementation of the interface method are correct, but I missed the change on the doc comments for the interface method entry itself.