### PR TITLE
gosec: Wrap os.Open calls with filepath.Clean

### DIFF
--- a/activefile/activefile.go
+++ b/activefile/activefile.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -123,7 +124,7 @@ func (afr activeFileReader) filterEntries(validPrefixes []string) ([]ezproxy.Fil
 
 	ezproxy.Logger.Printf("filterEntries: Attempting to open %q\n", afr.Filename)
 
-	f, err := os.Open(afr.Filename)
+	f, err := os.Open(filepath.Clean(afr.Filename))
 	if err != nil {
 		return nil, fmt.Errorf("func filterEntries: error encountered opening file %q: %w", afr.Filename, err)
 	}

--- a/auditlog/auditlog.go
+++ b/auditlog/auditlog.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -149,7 +150,7 @@ func (alr auditLogReader) AllSessionEntries() (SessionEntries, error) {
 
 	ezproxy.Logger.Printf("Attempting to open %q\n", alr.Filename)
 
-	f, err := os.Open(alr.Filename)
+	f, err := os.Open(filepath.Clean(alr.Filename))
 	if err != nil {
 		return nil, fmt.Errorf("func AllSessionEntries: error encountered opening file %q: %w", alr.Filename, err)
 	}


### PR DESCRIPTION
Even though [`G304`](https://securego.io/docs/rules/g304.html) isn't being triggered by the current usage I've gone ahead and wrapped the `os.Open` calls anyway. This should provide the same end result, while applying the potential protections afforded by the use of `filepath.Clean`.

fixes GH-26