### PR TITLE
errcheck: Explicitly check file close return vals

### DIFF
--- a/activefile/activefile.go
+++ b/activefile/activefile.go
@@ -131,7 +131,15 @@ func (afr activeFileReader) filterEntries(validPrefixes []string) ([]ezproxy.Fil
 	if err != nil {
 		return nil, fmt.Errorf("func filterEntries: error encountered opening file %q: %w", afr.Filename, err)
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			ezproxy.Logger.Printf(
+				"filterEntries: failed to close file %q: %s",
+				afr.Filename,
+				err.Error(),
+			)
+		}
+	}()
 
 	s := bufio.NewScanner(f)
 

--- a/auditlog/auditlog.go
+++ b/auditlog/auditlog.go
@@ -154,7 +154,15 @@ func (alr auditLogReader) AllSessionEntries() (SessionEntries, error) {
 	if err != nil {
 		return nil, fmt.Errorf("func AllSessionEntries: error encountered opening file %q: %w", alr.Filename, err)
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			ezproxy.Logger.Printf(
+				"AllSessionEntries: failed to close file %q: %s",
+				alr.Filename,
+				err.Error(),
+			)
+		}
+	}()
 
 	ezproxy.Logger.Printf("Searching for: %q\n", alr.Username)
 


### PR DESCRIPTION
- Wrap deferred `f.Close()` with logging
- Note origin func

fixes GH-31