### PR TITLE
Log original and sanitized filenames

### DIFF
--- a/activefile/activefile.go
+++ b/activefile/activefile.go
@@ -125,7 +125,14 @@ func NewReader(username string, filename string) (ezproxy.SessionsReader, error)
 // handle converting these entries to UserSession values.
 func (afr activeFileReader) filterEntries(validPrefixes []string) ([]ezproxy.FileEntry, error) {
 
-	ezproxy.Logger.Printf("filterEntries: Attempting to open %q\n", afr.Filename)
+	ezproxy.Logger.Printf(
+		"filterEntries: Request to open %q received\n",
+		afr.Filename,
+	)
+	ezproxy.Logger.Printf(
+		"filterEntries: Attempting to open sanitized version of file %q\n",
+		filepath.Clean(afr.Filename),
+	)
 
 	f, err := os.Open(filepath.Clean(afr.Filename))
 	if err != nil {

--- a/auditlog/auditlog.go
+++ b/auditlog/auditlog.go
@@ -148,7 +148,14 @@ func (alr auditLogReader) AllSessionEntries() (SessionEntries, error) {
 		EventLogout,
 	}
 
-	ezproxy.Logger.Printf("Attempting to open %q\n", alr.Filename)
+	ezproxy.Logger.Printf(
+		"AllSessionEntries: Request to open %q received\n",
+		alr.Filename,
+	)
+	ezproxy.Logger.Printf(
+		"AllSessionEntries: Attempting to open sanitized version of file %q\n",
+		filepath.Clean(alr.Filename),
+	)
 
 	f, err := os.Open(filepath.Clean(alr.Filename))
 	if err != nil {


### PR DESCRIPTION
Instead of logging the unsanitized filename and opening the sanitized version (could lead to confusion when
troubleshooting file access issues).

refs GH-26