### PR TITLE
gosec (G204): Mute subprocess linting error

### DIFF
--- a/terminate.go
+++ b/terminate.go
@@ -74,10 +74,12 @@ func TerminateUserSession(executable string, sessions ...UserSession) TerminateU
 			session.Username,
 		)
 
-		// cmd := exec.Command(
-		// 	"echo",
-		// 	"hello",
-		// )
+		// Accepting variables here is intentional; we need to provide the
+		// flexibility for client code to pass-in site-specific values. This
+		// allows for custom EZproxy installations which may place the
+		// application and associated files in a non-default location.
+		//
+		// nolint:gosec
 		cmd := exec.Command(
 			executable,
 			SubCmdNameSessionTerminate,


### PR DESCRIPTION
Mute the gosec warning for our particular use case.

Because this library is intended to allow client code to specify custom locations and values we *need* to allow client code-provided values in our exec.Command call.

fixes GH-32