### PR TITLE
Fix gocritic commentFormatting linting errors

### DIFF
--- a/activefile/activefile.go
+++ b/activefile/activefile.go
@@ -161,7 +161,7 @@ func (afr activeFileReader) filterEntries(validPrefixes []string) ([]ezproxy.Fil
 	for s.Scan() {
 		lineno++
 		currentLine := s.Text()
-		//ezproxy.Logger.Printf("Scanned line %d from %q: %q\n", lineno, filename, currentLine)
+		// ezproxy.Logger.Printf("Scanned line %d from %q: %q\n", lineno, filename, currentLine)
 
 		currentLine = strings.TrimSpace(currentLine)
 		// ezproxy.Logger.Printf("Line %d from %q after whitespace removal: %q\n",

--- a/terminate.go
+++ b/terminate.go
@@ -96,7 +96,7 @@ func TerminateUserSession(executable string, sessions ...UserSession) TerminateU
 		var cmdStdOut bytes.Buffer
 		cmd.Stdout = &cmdStdOut
 
-		//setup buffer to capture stderr
+		// setup buffer to capture stderr
 		var cmdStdErr bytes.Buffer
 		cmd.Stderr = &cmdStdErr
 


### PR DESCRIPTION
Revealed from the last golangci-lint update.