### PR TITLE
Update node-version to use "latest LTS" keyword

### DIFF
--- a/.github/workflows/lint-docs.yml
+++ b/.github/workflows/lint-docs.yml
@@ -35,7 +35,7 @@ jobs:
         # https://github.com/actions/setup-node
         uses: actions/setup-node@v2.2.0
         with:
-          node-version: "10.x"
+          node-version: "lts/*"
 
       - name: Install Markdown linting tools
         run: |


### PR DESCRIPTION
fixes GH-60