### PR TITLE
Ignore false-positive gosec G307 linting errors

### DIFF
--- a/activefile/activefile.go
+++ b/activefile/activefile.go
@@ -138,6 +138,10 @@ func (afr activeFileReader) filterEntries(validPrefixes []string) ([]ezproxy.Fil
 	if err != nil {
 		return nil, fmt.Errorf("func filterEntries: error encountered opening file %q: %w", afr.Filename, err)
 	}
+
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := f.Close(); err != nil {
 			// Ignore "file already closed" errors

--- a/auditlog/auditlog.go
+++ b/auditlog/auditlog.go
@@ -161,6 +161,10 @@ func (alr auditLogReader) AllSessionEntries() (SessionEntries, error) {
 	if err != nil {
 		return nil, fmt.Errorf("func AllSessionEntries: error encountered opening file %q: %w", alr.Filename, err)
 	}
+
+	// #nosec G307
+	// Believed to be a false-positive from recent gosec release
+	// https://github.com/securego/gosec/issues/714
 	defer func() {
 		if err := f.Close(); err != nil {
 			// Ignore "file already closed" errors


### PR DESCRIPTION
Issues reported after upgrading golangci-lint to v1.43.0. gosec was updated in that version from v2.8.1 to v2.9.1.

- fixes GH-70
- refs golangci/golangci-lint#2299