### PR TITLE
Apply linting fixes for Go 1.19 release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ lintinstall:
 	@export PATH="${PATH}:$(go env GOPATH)/bin"
 
 	@echo "Explicitly enabling Go modules mode per command"
-	(cd; GO111MODULE="on" go get honnef.co/go/tools/cmd/staticcheck)
+	go install honnef.co/go/tools/cmd/staticcheck@latest
 
 	@echo Installing latest stable golangci-lint version per official installation script ...
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin

--- a/activefile/doc.go
+++ b/activefile/doc.go
@@ -15,11 +15,10 @@
 // limitations under the License.
 
 /*
-
 Package activefile is intended for the processing of EZproxy active users and
 hosts files.
 
-OVERVIEW
+# Overview
 
 There is only ever one Active Users and Hosts "state" file at a time. While
 Host entries are (from what can be observed) consolidated on one line, session
@@ -28,7 +27,7 @@ space-separated fields. These order-specific lines and fields are joined in
 order to reconstruct a User Session that reflects active user sessions within
 EZproxy.
 
-KNOWN TYPES
+# Known Types
 
 Known entry types include (but may not be limited to):
 
@@ -39,7 +38,7 @@ Username or Login (L)
 
 Currently, only the last two types (S, L) are relevant to our purposes.
 
-UNKNOWN TYPES
+# Unknown Types
 
 These types have been observed, but not researched sufficiently to identify
 their purpose (Pull Requests for this are welcome!):
@@ -48,7 +47,7 @@ P
 M
 s (lowercase letter)
 
-LINE ORDERING
+# Line Ordering
 
 For our purposes, we match lines that start with a capital letter S and pair
 it with the first line following it that begins with a capital letter L. We
@@ -67,7 +66,7 @@ and:
 S
 L
 
-FIELD NUMBERS
+# Field Numbers
 
 The line for for Logins (L) is composed of 2 fields:
 
@@ -88,7 +87,7 @@ The line for Sessions (S) is composed of 11 fields:
 10) unknown, 0 is recorded
 11) unknown, asterisk is recorded
 
-RACE CONDITION
+# Race Condition
 
 NOTE: EZproxy does not immediately update the Active Users and Hosts "state"
 file with state changes; when a user account logs in/out, there is a race
@@ -98,6 +97,5 @@ Sessions. In an effort to workaround this race condition, this package
 attempts to retry session read attempts a limited number of times by default
 before giving up. This retry behavior (including a delay between retry
 attempts) can be modified by the caller as needed.
-
 */
 package activefile

--- a/auditlog/doc.go
+++ b/auditlog/doc.go
@@ -15,10 +15,9 @@
 // limitations under the License.
 
 /*
-
 Package auditlog is intended for the processing of EZproxy audit log files.
 
-OVERVIEW
+# Overview
 
 EZproxy can be configured to record a variety of audit/security related log
 entries to each daily audit log file. The specific events recorded vary based
@@ -42,7 +41,7 @@ library may be further updated to expose those details to client applications
 (e.g., number of failed login attempts and whether a set of failed login
 attempts eventually resulted in a successful login).
 
-FIELD TYPES
+# Field Types
 
 Each audit log file is composed of tab-separated fields, so presumably a CSV
 reader could (and perhaps in hindsight *should*) be used with this file. As of
@@ -58,7 +57,7 @@ the field names below are taken directly from a real audit log file.
 
 Currently we only deal with the first 5 fields.
 
-RACE CONDITION
+# Race Condition
 
 NOTE: EZproxy does not immediately update the Active Users and Hosts "state"
 file with state changes; when a user account logs in/out, there is a race
@@ -72,6 +71,5 @@ attempts) can be modified by the caller as needed.
 This race condition is also believed to affect the audit log, so the same
 retry/retry delay behavior is provided for the audit log Reader as with the
 active file reader.
-
 */
 package auditlog

--- a/ezproxy.go
+++ b/ezproxy.go
@@ -17,7 +17,7 @@
 package ezproxy
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"time"
@@ -36,7 +36,7 @@ func init() {
 	// Disable logging output by default unless client code explicitly
 	// requests it
 	Logger = log.New(os.Stderr, "[ezproxy] ", 0)
-	Logger.SetOutput(ioutil.Discard)
+	Logger.SetOutput(io.Discard)
 
 }
 
@@ -51,7 +51,7 @@ func EnableLogging() {
 // all logging output.
 func DisableLogging() {
 	Logger.SetFlags(0)
-	Logger.SetOutput(ioutil.Discard)
+	Logger.SetOutput(io.Discard)
 }
 
 // These "SessionsLimit" constants are used as preallocation values for maps


### PR DESCRIPTION
- Go doc comment formatting fixes
- Swap io/ioutil package for io package