### PR TITLE
Disable unsupported build opts in monthly workflow

### DIFF
--- a/.github/workflows/scheduled-monthly.yml
+++ b/.github/workflows/scheduled-monthly.yml
@@ -19,3 +19,7 @@ jobs:
   monthly:
     name: Monthly Tasks
     uses: atc0005/shared-project-resources/.github/workflows/scheduled-monthly.yml@master
+    with:
+      build-packages: false
+      build-podman-release: false
+


### PR DESCRIPTION
- explicitly disable building packages
- explicitly disable generating release builds using podman